### PR TITLE
feat: revoke tokens through logout mutation

### DIFF
--- a/src/entity/User.ts
+++ b/src/entity/User.ts
@@ -30,6 +30,9 @@ class User {
 
   @Column()
   password: string;
+
+  @Column('int', { default: 0 })
+  tokenVersion: number;
 }
 
 export default User;

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,12 @@ const connectToDatabase = async () => {
     app.use(helmet.referrerPolicy({ policy: 'same-origin' }));
   }
 
-  app.use(cors());
+  app.use(
+    cors({
+      origin: 'http://localhost:3002',
+      credentials: true,
+    })
+  );
 
   app.use(cookieParser());
 

--- a/src/mocked_data/auth.ts
+++ b/src/mocked_data/auth.ts
@@ -15,10 +15,16 @@ export const authRepositorySuccessfulMocks: RepositoryMock<MyActions> = {
       ...MOCKED_REGISTERED_USER,
     });
   },
+  logout: (repositoryStub) => {
+    repositoryStub.increment.resolves();
+  },
 };
 
 export const authRepositoryUnsuccessfullyMocks: RepositoryMock<MyActions> = {
   login: (repositoryStub) => {
     repositoryStub.findOneBy.resolves(null);
+  },
+  logout: (repositoryStub) => {
+    repositoryStub.increment.resolves();
   },
 };

--- a/src/mocked_data/user.ts
+++ b/src/mocked_data/user.ts
@@ -29,6 +29,16 @@ export const MOCKED_REGISTERED_USER = {
   username: `${MOCKED_FIRST_NAME} ${MOCKED_LAST_NAME}`,
 };
 
+export const MOCKED_REGISTERED_USER_WITH_TOKEN = {
+  _id: MOCKED_USER_ID,
+  avatar: null,
+  firstName: MOCKED_FIRST_NAME,
+  lastName: MOCKED_LAST_NAME,
+  email: MOCKED_EMAIL,
+  username: `${MOCKED_FIRST_NAME} ${MOCKED_LAST_NAME}`,
+  tokenVersion: 0,
+};
+
 export const MOCKED_USERS = [
   ...new Array(3).fill(null).map(() => ({
     _id: faker.datatype.uuid(),
@@ -47,16 +57,16 @@ export const userRepositoryMocks: RepositoryMock<MyActions> = {
   registerUser: (repositoryStub) => {
     repositoryStub.findOneBy.resolves(null);
     repositoryStub.create.returns({
-      ...MOCKED_REGISTERED_USER,
+      ...MOCKED_REGISTERED_USER_WITH_TOKEN,
     });
     repositoryStub.save.resolves();
   },
   updateUser: (repositoryStub) => {
-    repositoryStub.findOneByOrFail.resolves({ ...MOCKED_REGISTERED_USER });
+    repositoryStub.findOneByOrFail.resolves({ ...MOCKED_REGISTERED_USER_WITH_TOKEN });
     repositoryStub.update.resolves();
   },
   getUserById(repositoryStub) {
-    repositoryStub.findOneByOrFail.resolves({ ...MOCKED_REGISTERED_USER });
+    repositoryStub.findOneByOrFail.resolves({ ...MOCKED_REGISTERED_USER_WITH_TOKEN });
   },
   getUsers(repositoryStub) {
     repositoryStub.find.resolves([...MOCKED_USERS]);
@@ -66,7 +76,7 @@ export const userRepositoryMocks: RepositoryMock<MyActions> = {
 export const userRepositoryUnsuccessfullyMocks: RepositoryMock<'registerUser'> = {
   registerUser: (repositoryStub) => {
     repositoryStub.findOneBy.resolves({
-      ...MOCKED_REGISTERED_USER,
+      ...MOCKED_REGISTERED_USER_WITH_TOKEN,
     });
   },
 };

--- a/src/resolvers/AuthResolver/types/AuthResponseUnion.ts
+++ b/src/resolvers/AuthResolver/types/AuthResponseUnion.ts
@@ -1,14 +1,14 @@
 import { createUnionType } from 'type-graphql';
-import ErrorResponse from '../../types/ErrorResponse';
+import ResponseStatus from '../../types/ResponseStatus';
 import AuthData from './AuthData';
 
 const AuthResponseUnion = createUnionType({
   name: 'AuthResponse', // the name of the GraphQL union
   // function that returns tuple of object types classes
-  types: () => [AuthData, ErrorResponse] as const,
+  types: () => [AuthData, ResponseStatus] as const,
   resolveType: (value) => {
     if ('success' in value) {
-      return ErrorResponse; // we can return object type class (the one with `@ObjectType()`)
+      return ResponseStatus; // we can return object type class (the one with `@ObjectType()`)
     }
     if ('user' in value) {
       return AuthData; // or the schema name of the type as a string

--- a/src/resolvers/UserResolver/__tests__/UserResolver.test.ts
+++ b/src/resolvers/UserResolver/__tests__/UserResolver.test.ts
@@ -22,7 +22,7 @@ const registerUserMutation = `
         registerUser(
           input: $data
         ) {
-          ... on ErrorResponse {
+          ... on ResponseStatus {
             success
             message
           }
@@ -96,6 +96,8 @@ describe('User Resolver', () => {
     expect(mockedExpressResponse.cookies.pub).toBeDefined();
     expect(mockedExpressResponse.cookies.pub).toHaveProperty('value');
     expect(mockedExpressResponse.cookies.pub).toHaveProperty('options.httpOnly', true);
+    expect(mockedExpressResponse.cookies.pub).toHaveProperty('options.path', '/refresh-token');
+
     Container.reset(containerId);
   });
 

--- a/src/resolvers/UserResolver/index.ts
+++ b/src/resolvers/UserResolver/index.ts
@@ -41,8 +41,13 @@ export default class UserResolver {
     });
 
     await this.repository.save(newUser);
-    const { accessToken, refreshToken, expiresIn } = generateTokens(newUser._id.toString());
-    res.cookie('pub', refreshToken, { httpOnly: true });
+
+    const { accessToken, refreshToken, expiresIn } = generateTokens(
+      newUser._id.toString(),
+      newUser.tokenVersion
+    );
+
+    res.cookie('pub', refreshToken, { httpOnly: true, path: '/refresh-token' });
     return {
       user: { ...newUser },
       auth: { accessToken, expiresIn },

--- a/src/resolvers/types/ResponseStatus.ts
+++ b/src/resolvers/types/ResponseStatus.ts
@@ -1,7 +1,7 @@
 import { Field, ObjectType } from 'type-graphql';
 
 @ObjectType()
-export default class ErrorResponse {
+export default class ResponseStatus {
   @Field()
   message: string;
 

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -9,13 +9,13 @@ import {
 export const generateAccessToken = (userId: string) =>
   jwt.sign({ id: userId }, ACCESS_TOKEN_SECRET, { expiresIn: TOKEN_EXPIRATION });
 
-export const generateRefreshToken = (userId: string) =>
-  jwt.sign({ id: userId }, REFRESH_TOKEN_SECRET, {
+export const generateRefreshToken = (userId: string, tokenVersion: number) =>
+  jwt.sign({ id: userId, tokenVersion }, REFRESH_TOKEN_SECRET, {
     expiresIn: TOKEN_REFRESH_EXPIRATION,
   });
 
-export const generateTokens = (userId: string) => ({
+export const generateTokens = (userId: string, tokenVersion: number) => ({
   accessToken: generateAccessToken(userId),
-  refreshToken: generateRefreshToken(userId),
+  refreshToken: generateRefreshToken(userId, tokenVersion),
   expiresIn: TOKEN_EXPIRATION,
 });


### PR DESCRIPTION
Save tokenVersion integer field at User model and increment this as the user logouts from the app. The refresh token handler should compare the current user version and JWT payload version to give the token back.

Also send an empty string as response cookie header in order to delete the refresh token from cookies.